### PR TITLE
Add maintenance label to renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "labels": [
+    "maintenance"
   ]
 }


### PR DESCRIPTION
## Summary

This pull request includes a small change to the `renovate.json` file. The change adds a "maintenance" label to the configuration.

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R5-R7): Added a "maintenance" label to the configuration.

### Checklist

- [x] The pull-request title follows the [guidelines](https://chris.beams.io/posts/git-commit/)
- [x] The branch is up-to-date with the latest changes
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have updated the documentation to cover aspects affected by the changes
